### PR TITLE
Auto-generate intermediate "noname" regulatory file.

### DIFF
--- a/.tests/integration/config/config.yaml
+++ b/.tests/integration/config/config.yaml
@@ -2,7 +2,7 @@
 ref: "resources/ref.fasta.gz"
 ann: "resources/annotations.gtf.gz"
 regions: "resources/regions.bed"
-highlights: "resources/highlights.bed"
+regulatory: "resources/highlights.bed"
 encode_blacklist: "resources/encode_blacklist.bed"
 severus_vntrs: "resources/severus_vntrs.bed"
 chrom_sizes: "resources/hg38.chrom.sizes"

--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -2,7 +2,7 @@
 ref: "/path/to/reference/genome.fa.gz"
 ann: "/path/to/annotation/gencode.v45.gtf.gz"
 regions: "/path/to/regions/targets.bed"
-highlights: "/path/to/highlights/promoters.bed"
+regulatory: "/path/to/highlights/promoters.bed"
 encode_blacklist: "/path/to/blacklist/encode_blacklist.bed.gz"
 severus_vntrs: "/path/to/vntrs/human_trf.bed"
 chrom_sizes: "/path/to/chrom_info/hg38.chrom.sizes"

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -288,12 +288,23 @@ rule modkit_pileup:
           --log-filepath {log}
     """
 
+rule regulatory_noname:
+    input:
+        bed=config["regulatory"],
+    output:
+        bed="results/regulatory_noname/regulatory_noname.bed"
+    log:
+        "logs/regulatory_noname/regulatory_noname.log"
+    shell:"""
+        cut -f1-3 {input.bed} > {output.bed} 2> {log}
+    """
+
 rule modkit_entropy:
     input:
         bam="results/primary/{patient}/{sampleid}.bam",
         bai="results/primary/{patient}/{sampleid}.bam.bai",
         ref="results/decompress_ref/ref.fa",
-        regions=config["regions"],
+        regions=config["regulatory"],
     output:
         regions="results/modkit/entropy/{patient}/{sampleid}/regions.bed",
         windows="results/modkit/entropy/{patient}/{sampleid}/windows.bedgraph",
@@ -315,8 +326,10 @@ rule modkit_entropy:
           --ref {input.ref} \
           --regions {input.regions} \
           --cpg \
+          --window-size 100 \
           --threads {threads} \
-          --log-filepath {log}
+          --log-filepath {log} \
+          --verbose-logging
     """
 
 rule decompress_ref:
@@ -359,7 +372,7 @@ rule methylartist:
         bams=get_bams,
         ann=config["ann"],
         ref="results/decompress_ref/ref.fa",
-        hl=config["highlights"],
+        hl="results/regulatory_noname/regulatory_noname.bed",
     output:
         png="results/methylartist/{patient}/{label}.{modtype}.png"
     log:
@@ -398,7 +411,7 @@ rule methylartist_phased:
         bam="results/clair3/{patient}/{sampleid}/phased_output.bam",
         ann=config["ann"],
         ref="results/decompress_ref/ref.fa",
-        hl=config["highlights"],
+        hl="results/regulatory_noname/regulatory_noname.bed",
     output:
         png="results/methylartist_phased/{patient}/{label}.{sampleid}.png"
     log:


### PR DESCRIPTION
Methylartist uses a non-standard BED format, where the fourth column is expected to be an (option) colour. Since the full regulatory file has gene symbols in that column we need to create a cropped intermediate file.