### PR TITLE
Add rule for Wakhan

### DIFF
--- a/.tests/integration/config/config.yaml
+++ b/.tests/integration/config/config.yaml
@@ -17,6 +17,8 @@ minq: 9
 methylartist:
   enabled: True
   mods: ["m"]
+wakhan:
+    cut_threshold: 50
 smoothtools:
     bin: 1000000
     chunk: 500000
@@ -29,6 +31,7 @@ samples:
     sample1_tumor:
       pod5: "resources/reads.pod5"
       colour: "#D40000"
+      normal: False
 
 # Resource specifications for different steps
 resources:
@@ -51,6 +54,11 @@ resources:
     runtime: 420
     mem_mb: 64000
     threads: 24
+  wakhan:
+    partition: main
+    threads: 52
+    mem_mb: 512000
+    runtime: 240
   smoothcov:
     partition: short
     threads: 8

--- a/.tests/integration/config/config.yaml
+++ b/.tests/integration/config/config.yaml
@@ -6,6 +6,7 @@ regulatory: "resources/highlights.bed"
 encode_blacklist: "resources/encode_blacklist.bed"
 severus_vntrs: "resources/severus_vntrs.bed"
 chrom_sizes: "resources/hg38.chrom.sizes"
+target_genes: "resources/target_genes.bed"
 
 # Tool paths
 dorado_bin: "resources/dorado/bin/dorado"
@@ -19,6 +20,7 @@ methylartist:
   mods: ["m"]
 wakhan:
     cut_threshold: 50
+    contigs: chr1-22
 smoothtools:
     bin: 1000000
     chunk: 500000
@@ -56,8 +58,8 @@ resources:
     threads: 24
   wakhan:
     partition: main
-    threads: 52
-    mem_mb: 512000
+    threads: 12
+    mem_mb: 24000
     runtime: 240
   smoothcov:
     partition: short

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This is a Snakemake workflow for analyzing Oxford Nanopore Technologies (ONT) se
   - ClairS for somatic variant detection in tumor-normal pairs
   - Sniffles2 for germline structural variation detection
   - Severus for germline and somatic structural variation detection
+- **Copy Number Aberration Analysis**: Uses Wakhan for copy number estimation
 
 ## Requirements
 
@@ -82,6 +83,7 @@ snakemake --use-conda --profile slurm
    - Somatic variant detection with ClairS (for tumor-normal pairs)
    - Germline structural variant detection with Sniffles2
    - Germline/somatic structural variation detection with Severus
+8. **Copy Number Aberration Analysis**: Generate haplotype-specific coverage plots with Wakhan
 
 ## Output Structure
 
@@ -99,7 +101,8 @@ results/
 ├── clair3/                # Small variant calls
 ├── sniffles/              # Structural variant calls
 ├── severus/               # Tandem repeat expansions
-└── clairs/                # Somatic variants
+├── clairs/                # Somatic variants
+└── wakhan/                # Copy number aberrations
 ```
 
 ## Testing

--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -16,6 +16,8 @@ minq: 9
 methylartist:
   enabled: True
   mods: ["m", "h"]
+wakhan:
+  cut_threshold: 50
 smoothtools:
     bin: 1000000
     chunk: 500000
@@ -76,6 +78,11 @@ resources:
     mem_mb: 64000
     threads: 24
     params_extra: "/path/to/clair3"
+  wakhan:
+    partition: main
+    threads: 52
+    mem_mb: 512000
+    runtime: 240
   smoothcov:
     partition: short
     threads: 8

--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -6,6 +6,7 @@ regulatory: "/path/to/highlights/promoters.bed"
 encode_blacklist: "/path/to/blacklist/encode_blacklist.bed.gz"
 severus_vntrs: "/path/to/vntrs/human_trf.bed"
 chrom_sizes: "/path/to/chrom_info/hg38.chrom.sizes"
+target_genes: "/path/to/target_genes/target_genes.bed"
 
 # Tool paths
 dorado_bin: "/path/to/dorado/bin/dorado"
@@ -18,6 +19,7 @@ methylartist:
   mods: ["m", "h"]
 wakhan:
   cut_threshold: 50
+  contigs: chr1-22
 smoothtools:
     bin: 1000000
     chunk: 500000
@@ -80,8 +82,8 @@ resources:
     params_extra: "/path/to/clair3"
   wakhan:
     partition: main
-    threads: 52
-    mem_mb: 512000
+    threads: 12
+    mem_mb: 24000
     runtime: 240
   smoothcov:
     partition: short

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -3,6 +3,11 @@ import os
 
 configfile: "config/config.yaml"
 
+wildcard_constraints:
+    patient="[^/]+",
+    sampleid="[^/]+"
+
+
 def get_resource(rule, resource):
     try:
         return config["resources"][rule][resource]
@@ -34,6 +39,7 @@ def input_main(wc):
             o.append(f"results/modkit/calls/{patient}/{sampleid}.tsv")
             o.append(f"results/sniffles/{patient}/{sampleid}.vcf.gz")
             o.append(f"results/severus/{patient}/{sampleid}")
+            o.append(f"results/wakhan/{patient}/{sampleid}")
             o.append(f"results/smoothcov/{patient}/{sampleid}.csv")
             o.append(f"results/smoothmods/{patient}/{sampleid}.csv")
             o.append(f"results/binsnvs/{patient}/{sampleid}.csv")
@@ -612,6 +618,70 @@ rule clairs:
             --include_all_ctgs \
             --output_dir $(dirname /{output}) \
             --conda_prefix /opt/conda/envs/clairs
+    """
+
+
+def get_vcf_normal_phased(wc):
+    """use the 'normal' sample for tumor-normal mode; if not available, 
+    use tumor-only mode"""
+
+    for sample in config["samples"][wc.patient]:
+        s = config["samples"][wc.patient][sample]
+        # check that there's a control sample for the patient, and that it's not
+        # the same sample as the target
+        if "normal" in s and s["normal"] and sample != wc.sampleid:
+            return f" --normal-phased-vcf results/clair3/{wc.patient}/{sample}/phased_merge_output.vcf.gz"
+    
+    return f" --tumor-vcf results/clair3/{wc.patient}/{wc.sampleid}/phased_merge_output.vcf.gz"
+
+
+def get_breakpoints(wc):
+    """use severus_somatic.vcf for tumor-normal mode; 
+    if not available, use severus_all.vcf"""
+
+    for sample in config["samples"][wc.patient]:
+        s = config["samples"][wc.patient][sample]
+        # check that there's a control sample for the patient, and that it's not
+        # the same sample as the target
+        if sample != wc.sampleid and "normal" in s and s["normal"]:
+            return f"--breakpoints results/severus/{wc.patient}/{wc.sampleid}/somatic_SVs/severus_somatic.vcf"
+
+    return f" --breakpoints results/severus/{wc.patient}/{wc.sampleid}/all_SVs/severus_all.vcf"  
+
+
+rule wakhan:
+    input:
+        bam_tumour="results/primary/{patient}/{sampleid}.bam",
+        ref="results/decompress_ref/ref.fa",
+        severus_dir="results/severus/{patient}/{sampleid}"
+    output:
+        directory("results/wakhan/{patient}/{sampleid}")
+    log:
+        "logs/wakhan/{patient}/{sampleid}.log"
+    benchmark:
+        "logs/wakhan/{patient}/{sampleid}.bmk"
+    threads: get_resource("wakhan", "threads")
+    resources:
+        mem_mb=get_resource("wakhan", "mem_mb"),
+        runtime=get_resource("wakhan", "runtime"),
+        slurm_partition=get_resource("wakhan", "partition")
+    params:
+        vcf_normal_phased=get_vcf_normal_phased,
+        cut_threshold=config["wakhan"]["cut_threshold"],
+        breakpoints=get_breakpoints,
+    conda:
+        "envs/wakhan.yaml"
+    shell:"""
+        wakhan \
+            --threads {threads} \
+            --reference {input.ref} \
+            --target-bam {input.bam_tumour} \
+            {params.vcf_normal_phased} \
+            --genome-name {wildcards.sampleid} \
+            --out-dir-plots {output} \
+            {params.breakpoints} \
+            --cut-threshold {params.cut_threshold} \
+            --pdf-enable
     """
 
 

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -133,13 +133,13 @@ rule pycoqc:
 
 rule qsfilter:
     input:
-        "results/basecall_dorado/{sampleid}.bam",
+        "results/basecall_dorado/{patient}/{sampleid}.bam",
     output:
-        "results/qsfilter/{sampleid}.bam",
+        "results/qsfilter/{patient}/{sampleid}.bam",         
     log:
-        "logs/qsfilter/{sampleid}.log",
+        "logs/qsfilter/{patient}/{sampleid}.log",            
     benchmark:
-        "logs/qsfilter/{sampleid}.bmk"
+        "logs/qsfilter/{patient}/{sampleid}.bmk"             
     params:
         minq=config["minq"]
     threads: get_resource("qsfilter", "threads")

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -656,7 +656,8 @@ rule wakhan:
     input:
         bam_tumour="results/primary/{patient}/{sampleid}.bam",
         ref="results/decompress_ref/ref.fa",
-        severus_dir="results/severus/{patient}/{sampleid}"
+        severus_dir="results/severus/{patient}/{sampleid}",
+        target_genes=config["target_genes"]
     output:
         directory("results/wakhan/{patient}/{sampleid}")
     log:
@@ -672,6 +673,7 @@ rule wakhan:
         vcf_normal_phased=get_vcf_normal_phased,
         cut_threshold=config["wakhan"]["cut_threshold"],
         breakpoints=get_breakpoints,
+        contigs=config["wakhan"]["contigs"]
     conda:
         "envs/wakhan.yaml"
     shell:"""
@@ -684,6 +686,9 @@ rule wakhan:
             --out-dir-plots {output} \
             {params.breakpoints} \
             --cut-threshold {params.cut_threshold} \
+            --user-input-genes {input.target_genes}
+            --contigs {params.contigs}
+            --cpd-internal-segments
             --pdf-enable
     """
 

--- a/workflow/envs/wakhan.yaml
+++ b/workflow/envs/wakhan.yaml
@@ -1,0 +1,5 @@
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - wakhan==0.1.2

--- a/workflow/envs/wakhan.yaml
+++ b/workflow/envs/wakhan.yaml
@@ -2,4 +2,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - wakhan==0.1.2
+  - wakhan==0.2.0


### PR DESCRIPTION
The commands are well constructed, the problem seems to be with the testing files; I suspect this is because the vcf generated by Severus is empty, causing an IndexError in wakhan...  If the commands “--breakpoints {severus vcf}” and “--tumor-vcf {clair3 phased bam}” are removed, wakhan warns in its log that it needs them and finishes without giving any error in snakemake...

```
localrule wakhan:
    input: results/primary/sample1/sample1_tumor.bam, results/decompress_ref/ref.fa, results/severus/sample1/sample1_tumor
    output: results/wakhan/sample1/sample1_tumor
    log: logs/wakhan/sample1/sample1_tumor.log
    jobid: 14
    benchmark: logs/wakhan/sample1/sample1_tumor.bmk
    reason: Updated input files: results/severus/sample1/sample1_tumor, results/primary/sample1/sample1_tumor.bam
    wildcards: patient=sample1, sampleid=sample1_tumor
    resources: tmpdir=/tmp, mem_mb=512000, mem_mib=488282, runtime=240, slurm_partition=main

Waiting for more resources.
Activating conda environment: .snakemake/conda/69a0df7b257f2bd7fc6d5752576302aa_
[2025-08-05 14:00:25] INFO: Starting Wakhan 0.1.2
[2025-08-05 14:00:25] INFO: Cmd: /home/villena/Documentos/myeloma-epi-sv/.tests/integration/.snakemake/conda/69a0df7b257f2bd7fc6d5752576302aa_/bin/wakhan --threads 1 --reference results/decompress_ref/ref.fa --target-bam results/primary/sample1/sample1_tumor.bam --tumor-vcf results/clair3/sample1/sample1_tumor/phased_merge_output.vcf.gz --genome-name sample1_tumor --out-dir-plots results/wakhan/sample1/sample1_tumor --breakpoints results/severus/sample1/sample1_tumor/all_SVs/severus_all.vcf --cut-threshold 50 --pdf-enable
[2025-08-05 14:00:25] INFO: Python version: 3.10.18 | packaged by conda-forge | (main, Jun  4 2025, 14:45:41) [GCC 13.3.0]
/home/villena/Documentos/myeloma-epi-sv/.tests/integration/.snakemake/conda/69a0df7b257f2bd7fc6d5752576302aa_/lib/python3.10/site-packages/vcf_parser/__init__.py:3: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  from pkg_resources import require
[2025-08-05 14:00:25] INFO: Split variants = True
[2025-08-05 14:00:25] INFO: check info = True
[2025-08-05 14:00:25] INFO: Allele symbol = 0
[2025-08-05 14:00:25] INFO: Initializing HeaderParser
[2025-08-05 14:00:25] INFO: Reading vcf form file results/severus/sample1/sample1_tumor/all_SVs/severus_all.vcf
[2025-08-05 14:00:25] INFO: Setting self.individuals to ['tumour']
Traceback (most recent call last):
  File "/home/villena/Documentos/myeloma-epi-sv/.tests/integration/.snakemake/conda/69a0df7b257f2bd7fc6d5752576302aa_/bin/wakhan", line 10, in <module>
    sys.exit(main())
  File "/home/villena/Documentos/myeloma-epi-sv/.tests/integration/.snakemake/conda/69a0df7b257f2bd7fc6d5752576302aa_/lib/python3.10/site-packages/src/main.py", line 386, in main
    breakpoints_additional = extract_breakpoints_additional(args)
  File "/home/villena/Documentos/myeloma-epi-sv/.tests/integration/.snakemake/conda/69a0df7b257f2bd7fc6d5752576302aa_/lib/python3.10/site-packages/src/utils.py", line 2024, in extract_breakpoints_additional
    df_var_bins, df_var_bins_1 = get_chromosomes_bins(args.target_bam[0], args.bin_size, args)
  File "/home/villena/Documentos/myeloma-epi-sv/.tests/integration/.snakemake/conda/69a0df7b257f2bd7fc6d5752576302aa_/lib/python3.10/site-packages/src/utils.py", line 105, in get_chromosomes_bins
    bed = update_bins_with_bps(bed, bps, bps_bnd, args, region)
  File "/home/villena/Documentos/myeloma-epi-sv/.tests/integration/.snakemake/conda/69a0df7b257f2bd7fc6d5752576302aa_/lib/python3.10/site-packages/src/utils.py", line 211, in update_bins_with_bps
    bp_junctions.append([region[i] - 1, region[i]])
IndexError: list index out of range
```